### PR TITLE
feat: hide selection section during timer, add recipe accordion preview

### DIFF
--- a/src/app/features/brew-timer/BrewTimerHome.module.css
+++ b/src/app/features/brew-timer/BrewTimerHome.module.css
@@ -79,6 +79,108 @@
   color: rgb(71 85 105);
 }
 
+.accordionToggle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  margin-top: 1.25rem;
+  border: 1px solid rgb(226 232 240);
+  border-radius: 0.5rem;
+  background: transparent;
+  padding: 0.625rem 0.75rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: rgb(51 65 85);
+  cursor: pointer;
+  text-align: left;
+}
+
+.accordionToggle:hover {
+  background: rgb(248 250 252);
+}
+
+[aria-expanded="true"].accordionToggle {
+  border-radius: 0.5rem 0.5rem 0 0;
+  border-bottom-color: transparent;
+}
+
+.chevronDown {
+  font-size: 1.125rem;
+  line-height: 1;
+  transform: rotate(90deg);
+  display: inline-block;
+}
+
+.chevronUp {
+  font-size: 1.125rem;
+  line-height: 1;
+  transform: rotate(-90deg);
+  display: inline-block;
+}
+
+.recipeList {
+  margin-top: 0.25rem;
+  padding: 0;
+  list-style: none;
+  counter-reset: step;
+  border: 1px solid rgb(226 232 240);
+  border-top: 0;
+  border-radius: 0 0 0.5rem 0.5rem;
+  padding: 0 0.75rem;
+}
+
+.recipeStep {
+  counter-increment: step;
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.6rem 0;
+  border-bottom: 1px solid rgb(241 245 249);
+  font-size: 0.875rem;
+  color: rgb(51 65 85);
+}
+
+.recipeStep::before {
+  content: counter(step);
+  flex-shrink: 0;
+  width: 1.25rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: rgb(148 163 184);
+  text-align: right;
+}
+
+.recipeStepMessage {
+  flex: 1;
+}
+
+.recipeStepTime {
+  flex-shrink: 0;
+  font-size: 0.75rem;
+  font-variant-numeric: tabular-nums;
+  color: rgb(148 163 184);
+}
+
+.startButton {
+  margin-top: 1.25rem;
+  width: 100%;
+  border: 0;
+  border-radius: 0.5rem;
+  background: rgb(15 23 42);
+  padding: 0.75rem 1rem;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  font-weight: 600;
+  color: #fff;
+  cursor: pointer;
+}
+
+.startButton:hover {
+  background: rgb(30 41 59);
+}
+
 @media (min-width: 640px) {
   .container {
     padding-top: 2.5rem;

--- a/src/app/features/brew-timer/BrewTimerHome.tsx
+++ b/src/app/features/brew-timer/BrewTimerHome.tsx
@@ -17,6 +17,12 @@ function toValidPositiveNumber(value: string, fallback: number): number {
   return parsed;
 }
 
+function formatDeadline(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return `${m}:${String(s).padStart(2, "0")}`;
+}
+
 export function BrewTimerHome() {
   const [inputMode, setInputMode] = useState<InputMode>("readyCoffee");
   const [readyCoffeeMillilitersInput, setReadyCoffeeMillilitersInput] =
@@ -24,6 +30,8 @@ export function BrewTimerHome() {
   const [usedCoffeeGramsInput, setUsedCoffeeGramsInput] = useState(
     String(DEFAULT_USED_COFFEE_GRAMS),
   );
+  const [timerStarted, setTimerStarted] = useState(false);
+  const [recipeOpen, setRecipeOpen] = useState(false);
 
   const readyCoffeeMilliliters = useMemo(
     () =>
@@ -59,49 +67,83 @@ export function BrewTimerHome() {
           <p className={styles.subtitle}>Set your input mode and start brewing.</p>
         </header>
 
-        <section className={styles.card}>
-          <label className={styles.label}>
-            Input mode
-            <select
-              value={inputMode}
-              onChange={(e) => setInputMode(e.target.value as InputMode)}
-              className={styles.field}
-            >
-              <option value="readyCoffee">Total amount of coffee</option>
-              <option value="usedCoffee">Amount of used coffee (beans)</option>
-            </select>
-          </label>
+        {!timerStarted && (
+          <section className={styles.card}>
+            <label className={styles.label}>
+              Input mode
+              <select
+                value={inputMode}
+                onChange={(e) => setInputMode(e.target.value as InputMode)}
+                className={styles.field}
+              >
+                <option value="readyCoffee">Total amount of coffee</option>
+                <option value="usedCoffee">Amount of used coffee (beans)</option>
+              </select>
+            </label>
 
-          <label className={styles.label}>
-            {inputMode === "readyCoffee" ? "Ready coffee (ml)" : "Used coffee (g)"}
-            <input
-              type="number"
-              min={1}
-              step={1}
-              inputMode="numeric"
-              value={
-                inputMode === "readyCoffee"
-                  ? readyCoffeeMillilitersInput
-                  : usedCoffeeGramsInput
-              }
-              onChange={(e) => {
-                if (inputMode === "readyCoffee") {
-                  setReadyCoffeeMillilitersInput(e.target.value);
-                  return;
+            <label className={styles.label}>
+              {inputMode === "readyCoffee" ? "Ready coffee (ml)" : "Used coffee (g)"}
+              <input
+                type="number"
+                min={1}
+                step={1}
+                inputMode="numeric"
+                value={
+                  inputMode === "readyCoffee"
+                    ? readyCoffeeMillilitersInput
+                    : usedCoffeeGramsInput
                 }
-                setUsedCoffeeGramsInput(e.target.value);
-              }}
-              className={styles.field}
-            />
-          </label>
+                onChange={(e) => {
+                  if (inputMode === "readyCoffee") {
+                    setReadyCoffeeMillilitersInput(e.target.value);
+                    return;
+                  }
+                  setUsedCoffeeGramsInput(e.target.value);
+                }}
+                className={styles.field}
+              />
+            </label>
 
-          <p className={styles.helper}>
-            Using {totalWaterMilliliters} ml total water to calculate the recipe.
-          </p>
-        </section>
+            <p className={styles.helper}>
+              Using {totalWaterMilliliters} ml total water to calculate the recipe.
+            </p>
+
+            <button
+              onClick={() => setRecipeOpen((o) => !o)}
+              className={styles.accordionToggle}
+              aria-expanded={recipeOpen}
+            >
+              {recipeOpen ? "Hide recipe" : "Show recipe"}
+              <span className={recipeOpen ? styles.chevronUp : styles.chevronDown} aria-hidden>›</span>
+            </button>
+
+            {recipeOpen && (
+              <ol className={styles.recipeList}>
+                {steps.map((step, i) => (
+                  <li key={i} className={styles.recipeStep}>
+                    <span className={styles.recipeStepMessage}>{step.message}</span>
+                    <span className={styles.recipeStepTime}>{formatDeadline(step.deadline)}</span>
+                  </li>
+                ))}
+              </ol>
+            )}
+
+            <button
+              onClick={() => setTimerStarted(true)}
+              className={styles.startButton}
+            >
+              Start Brewing
+            </button>
+          </section>
+        )}
       </div>
 
-      <Timer steps={steps} />
+      {timerStarted && (
+        <Timer
+          steps={steps}
+          onReset={() => setTimerStarted(false)}
+        />
+      )}
     </main>
   );
 }

--- a/src/app/features/brew-timer/Timer.tsx
+++ b/src/app/features/brew-timer/Timer.tsx
@@ -8,9 +8,10 @@ import styles from "@/app/features/brew-timer/Timer.module.css";
 
 type Props = {
   steps: Array<BrewingStep>;
+  onReset?: () => void;
 };
 
-export function Timer({ steps }: Props) {
+export function Timer({ steps, onReset }: Props) {
   const { totalSeconds, isRunning, start, pause, reset } = useStopwatch({
     autoStart: false,
   });
@@ -40,6 +41,7 @@ export function Timer({ steps }: Props) {
   const handleReset = () => {
     setCurrentStepIndex(0);
     reset(undefined, false);
+    onReset?.();
   };
 
   const currentStep = steps[currentStepIndex];


### PR DESCRIPTION
- Selection section (inputs + recipe) is hidden once the timer view is active; reset brings it back
- Timer mounts only when "Start Brewing" is clicked and starts manually via its own Start button
- Recipe steps with formatted timestamps are toggled via a "Show recipe" accordion
- Added Start Brewing button and supporting CSS to BrewTimerHome